### PR TITLE
Add support for add-linters. Use fireplace#query to avoid callback/println

### DIFF
--- a/plugin/eastwood.vim
+++ b/plugin/eastwood.vim
@@ -22,7 +22,10 @@ function! g:EastwoodLintNS(...) abort
     let opts = a:0 ? a:1 : {}
     let add_linters = exists('opts.add_linters') ? opts.add_linters : []
 
-    let cmd = "(->> (eastwood.lint/lint {:namespaces '[" . fireplace#ns() . "] :add-linters [" . join(map(copy(add_linters), '":" . v:val'), " ") ."]})" .
+    let cmd = "(->> (eastwood.lint/lint { " .
+            \     " :namespaces '[" . fireplace#ns() . "]" .
+            \     " :add-linters [" . join(map(copy(add_linters), '":" . v:val'), " ") ."]" .
+            \ " })" .
             \ " :warnings" .
             \ " (map (fn [e]" .
             \     "{:text (:msg e)" .

--- a/plugin/eastwood.vim
+++ b/plugin/eastwood.vim
@@ -35,6 +35,7 @@ function! g:EastwoodLintNS(...) abort
             \     " :bufnr " . bufnr('%')  .
             \     " :type \"E\"})))"
     try
+        call g:EastwoodRequire() " In case if REPL was restarted
         let res=fireplace#query(cmd)
         return res
     catch /^Clojure:.*/

--- a/syntax_checkers/clojure/eastwood.vim
+++ b/syntax_checkers/clojure/eastwood.vim
@@ -26,38 +26,8 @@ function! SyntaxCheckers_clojure_eastwood_IsAvailable() dict
 endfunction
 
 function! SyntaxCheckers_clojure_eastwood_GetLocList() dict
-    let errorformat = '%f:%l:%c: %m'
-
-    let env = syntastic#util#isRunningWindows() ? {} : { 'TERM': 'dumb' }
-    
-    redir => eastwood_output
-    call g:EastwoodLintNS()
-    redir end
-    let result_array = split(eastwood_output, "\n")[1:]
-    let loclist = []
-
-    for message in result_array
-        let error = {}
-        let filename_idx = match(message, ":", 0, 1)
-        let filename = message[0 : filename_idx - 1]
-
-        let line_idx = match(message, ":", 0, 2)
-        let line = message[filename_idx + 1 : line_idx - 1]
-
-        let column_idx = match(message, ":", 0, 3)
-        let column = message[line_idx + 1 : column_idx - 1]
-        let msg = message[column_idx + 1 : ]
-
-        let error.text = msg
-        let error.lnum = line
-        let error.col = column
-        let error.valid = 1
-        let error.type = "E"
-        let error.bufnr = bufnr('%')
-        call add(loclist, error)
-    endfor
-
-    return loclist
+    let opts = {'add_linters': exists('g:eastwood_add_linters') ? g:eastwood_add_linters : []}
+    return g:EastwoodLintNS(opts)
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({

--- a/syntax_checkers/clojure/eastwood.vim
+++ b/syntax_checkers/clojure/eastwood.vim
@@ -26,6 +26,7 @@ function! SyntaxCheckers_clojure_eastwood_IsAvailable() dict
 endfunction
 
 function! SyntaxCheckers_clojure_eastwood_GetLocList() dict
+    let env = syntastic#util#isRunningWindows() ? {} : { 'TERM': 'dumb'  }
     let opts = {'add_linters': exists('g:eastwood_add_linters') ? g:eastwood_add_linters : []}
     return g:EastwoodLintNS(opts)
 endfunction


### PR DESCRIPTION
Hello, vim-eastwood is great, here is support for `:add-linters`. Don't have more time today to add the docs for `g:eastwood_add_linters`, will do in nearest time.

`:exclude-linters` could be added in same fashion.