### PR TITLE
feat: support :warn-data sub-key of :warnings items

### DIFF
--- a/plugin/eastwood.vim
+++ b/plugin/eastwood.vim
@@ -27,6 +27,7 @@ function! g:EastwoodLintNS(...) abort
             \     " :add-linters [" . join(map(copy(add_linters), '":" . v:val'), " ") ."]" .
             \ " })" .
             \ " :warnings" .
+            \ " (map (some-fn :warn-data identity))" .
             \ " (map (fn [e]" .
             \     "{:text (:msg e)" .
             \     " :lnum (:line e)"  .


### PR DESCRIPTION
looks like newer versions of eastwood push the data you are consuming
down inside a map keyed by :warn-data so this line should allow that
data to be queried, or fall back to the top level object